### PR TITLE
llm_inline to complete codes in-place

### DIFF
--- a/capabilities/__init__.py
+++ b/capabilities/__init__.py
@@ -1,2 +1,2 @@
 from .core import Capability
-from .dec import llm, AiFunction
+from .dec import llm, llm_inline, AiFunction

--- a/capabilities/dec.py
+++ b/capabilities/dec.py
@@ -147,14 +147,12 @@ def llm_inline(regenerate=True, num_tries=3):
             # Try to parse out the function body, but if unsuccessful, fall back to the original completion.
             processed = postprocess(completed, func.__name__)
             completed = processed if processed else completed
-
             new_decorator = f"@llm_inline(regenerate=False)"
             if input(f"The following code will be written to your file: \n{completed}\nContinue? (y/n)") == "y":
                 with open(inspect.getfile(func), "w") as f:
                     f.write(f"{code_before}\n{new_decorator}\n{completed}\n{code_after}")
 
                 # Reload the module and the functions
-
                 # todo: reload the script itself could result in ModuleNotFoundError: spec not found for the module '__main__'. Trying an dirty way.
                 try:
                     module = inspect.getmodule(func)
@@ -163,7 +161,6 @@ def llm_inline(regenerate=True, num_tries=3):
                     return getattr(module, func.__name__)
                 except:
                     exec(completed, globals())
-                    print(globals()[func.__name__])
                     return globals()[func.__name__]
 
 

--- a/capabilities/dec.py
+++ b/capabilities/dec.py
@@ -112,7 +112,6 @@ def llm(*args, **kwargs):  # type: ignore
         return functools.partial(AiFunction, *args, **kwargs)
 
 
-# todo: directly assign this as an attribute of `llm`? Or make `llm` a class?
 def llm_inline(regenerate=True, num_tries=3):
 
     @llm
@@ -134,7 +133,7 @@ def llm_inline(regenerate=True, num_tries=3):
         """
         ...
 
-    def wrapper(func: Callable[P, R]):
+    def wrapper(func: Callable[P, R]) -> Callable[P, R]:
         if not regenerate:  # no-op if `regenerate==False`
             return func
 
@@ -153,7 +152,8 @@ def llm_inline(regenerate=True, num_tries=3):
                     f.write(f"{code_before}\n{new_decorator}\n{completed}\n{code_after}")
 
                 # Reload the module and the functions
-                # todo: reload the script itself could result in ModuleNotFoundError: spec not found for the module '__main__'. Trying an dirty way.
+                # todo: reload the script itself could result in ModuleNotFoundError: spec not found for the module '__main__'.
+                #       Trying an dirty way but may need to explore best-practice later.
                 try:
                     module = inspect.getmodule(func)
                     importlib.reload(module)

--- a/capabilities/dec.py
+++ b/capabilities/dec.py
@@ -184,7 +184,6 @@ def postprocess(code: str, func_name: str) -> str:
     except SyntaxError:
         return ""
 
-    completed_func = None
     for node in parsed.body:
         if isinstance(node, ast.FunctionDef) and node.name == func_name:
             node.decorator_list = []


### PR DESCRIPTION
The first application of `@llm` should be its own extension `@llm_inline` lol.

It calls our `@llm` magic function to complete a function with signature+docstring, wait for human confirmation, write to file and execute.

The general idea is implemented, but there are some small hiccups from a few things:
- getting same return (from caching?) if I hit `no` too fast.
- `importlib.reload` has problems reloading `__main__`
- ~~in the fall-back solution, does `exec(...)` and then `globals()[func.__name__]` give me the function? Didn't get it working.~~ Worked now!

Also a question:
- Should the user interface be just like this (`llm_inline(...)`), or should we make it an attribute of `llm` and call `llm.inline(...)`?
- There is a `postprocess` function trying to parse out the function body (because LM doesn't always follow instructions and sometimes give me back the context). In the unsuccessful case, I make it fall back to the original return. But we can do something like retry 2 more times. From user point of view the reaction will get slower with better accuracy in return. Should we do retries?

Any input on module/function reloading? I feel like there should be a better solution.